### PR TITLE
Set up linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.py[cod]
+.*cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.254
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        args:
+          - --quiet

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # library-sandbox
+
 This is a beta sandbox of reusable steps for the Valohai ecosystem.
+
+## Development
+
+### Linting
+
+Linting/formatting happens via `pre-commit`. Install it with `pip install pre-commit` and:
+
+- run `pre-commit install` to install Git hooks if you like, or
+- run `pre-commit run` manually to run everything on staged files, or
+- `pre-commit run --all-files` to run everything on all files.
+
+The linters run by `pre-commit` are `ruff`, `black`, and `prettier`;
+you can (should) set up your IDE to run them automatically too.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,20 @@
+target-version = "py311"
+select = [
+    "B",
+    "C",
+    "E",
+    "F",
+    "I",
+    "RET",
+    "S",
+    "T",
+    "TRY",
+    "UP",
+    "W",
+]
+ignore = [
+    "C901",
+    "E501",
+    "T2",
+    "TRY003",
+]


### PR DESCRIPTION
This sets up a basic lint system:

* pre-commit runs linters
* ruff deals with Python linting
* black deals with Python formatting
* prettier deals with TOML/YAML/Markdown formatting

The Ruff rules could probably be loosened up when there's actual code in here, but this is a decent baseline.