### PR TITLE
Add second and third columns of data to example queries

### DIFF
--- a/valohai.yaml
+++ b/valohai.yaml
@@ -9,7 +9,7 @@
     parameters:
       - name: sql_query
         type: string
-        default: SELECT GETDATE() as current_datetime;
+        default: SELECT GETDATE() as current_datetime, 1 as one, 2 as two;
         description: SQL query to be executed
         widget: SQL
       - name: datum_alias
@@ -55,7 +55,7 @@
     parameters:
       - name: sql_query
         type: string
-        default: SELECT GETDATE() as current_datetime;
+        default: SELECT GETDATE() as current_datetime, 1 as one, 2 as two;
         description: SQL query to be executed
         widget: SQL
       - name: datum_alias
@@ -92,7 +92,7 @@
     parameters:
       - name: sql_query
         type: string
-        default: SELECT CURRENT_DATETIME() AS current_datetime;
+        default: SELECT CURRENT_DATETIME() AS current_datetime, 1 as one, 2 as two;
         description: SQL query to be executed
         widget: SQL
       - name: datum_alias


### PR DESCRIPTION
Fixes #24 

Default query use to produce one column CSV and its preview would have been confusing as we couldn't detect the delimiter character as there was none.

Now the results are beautiful: 
![kuva](https://github.com/valohai/library-sandbox/assets/20582490/9b711de0-9284-45c5-89fb-be598d64786e)

### Queries tested in staging:

**Snowflake** https://staging.valohai.com/p/Valohai-internal/library-sandbox/execution/01886783-79ac-fc1c-1586-034be59b881f/#info
**Bigquery** https://staging.valohai.com/p/Valohai-internal/library-sandbox/execution/0188676f-d4a4-d887-c6e9-271aa25af08f/#info
**Redshift** https://staging.valohai.com/p/Valohai-internal/library-sandbox/execution/0188676a-4fd6-f6d6-0e85-d4eaa154306f/#info