### PR TITLE
Upgrade GHA and pre-commit bits; switch to prek and uv in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
           cache: pip
@@ -34,8 +34,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3.11
-          cache: pip
-          cache-dependency-path: "**/requirements.txt"
+          cache-dependency-glob: "**/requirements.txt"
+          activate-environment: true
       - name: Install all requirements
-        run: find . -name requirements.txt | xargs -n1 pip install -r
-      - name: Install mypy
-        run: pip install mypy
+        run: find . -name requirements.txt | xargs -n1 uv pip install -r
+      - name: Install mypy and pip
+        run: uv pip install mypy pip
       - name: Create mypy cache directory
         run: mkdir -p /tmp/.cache/mypy
       - name: Run mypy
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3.11
-          cache: pip
-          cache-dependency-path: "**/requirements.txt"
-      - run: find . -name requirements.txt | xargs -n1 pip install -r
-      - run: pip install pytest-cov
-      - run: py.test -svv --cov . --cov-report term-missing
+          cache-dependency-glob: "**/requirements.txt"
+          activate-environment: true
+      - run: find . -name requirements.txt | xargs -n1 uv pip install -r
+      - run: uv pip install pytest-cov
+      - run: pytest -svv --cov . --cov-report term-missing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: 0671d8ab202c4ac093b78433ae5baf74f3fc7246 # frozen: v0.15.15
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - --fix
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1 # frozen: v3.8.3
     hooks:
       - id: prettier

--- a/models/nlp/qa/huggingface/inference.py
+++ b/models/nlp/qa/huggingface/inference.py
@@ -47,7 +47,7 @@ def predict(
         0,
         answer_start_index : answer_end_index + 1,
     ].cpu()
-    return tokenizer.decode(predict_answer_tokens)
+    return str(tokenizer.decode(predict_answer_tokens))
 
 
 def main():

--- a/models/nlp/qa/huggingface/train.py
+++ b/models/nlp/qa/huggingface/train.py
@@ -8,6 +8,7 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoTokenizer,
     DefaultDataCollator,
+    PreTrainedTokenizerBase,
     Trainer,
     TrainingArguments,
 )
@@ -18,7 +19,7 @@ from utils.torch import get_preferred_torch_device
 
 def prepare_train_features(
     examples: dict[str, Any],
-    tokenizer: AutoTokenizer,
+    tokenizer: PreTrainedTokenizerBase,
     max_length: int,
     doc_stride: int,
 ) -> dict[str, Any]:

--- a/models/nlp/summarization/huggingface/inference.py
+++ b/models/nlp/summarization/huggingface/inference.py
@@ -29,13 +29,13 @@ def predict(
         truncation=True,
     ).input_ids
     inputs = inputs.to(device)
-    outputs = model.generate(
+    outputs = model.generate(  # type: ignore[operator]
         inputs,
         max_new_tokens=max_summary_length,
         do_sample=False,
     )
     outputs = outputs.cpu()
-    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return str(tokenizer.decode(outputs[0], skip_special_tokens=True))
 
 
 def main():

--- a/models/nlp/utils/huggingface.py
+++ b/models/nlp/utils/huggingface.py
@@ -56,7 +56,7 @@ def load_huggingface_model_and_tokenizer(
         )
     tokenizer = tokenizer_type.from_pretrained(model_spec)
     model = model_type.from_pretrained(model_spec)
-    return tokenizer, model
+    return tokenizer, model  # type: ignore[return-value]
 
 
 def _load_from_zip(


### PR DESCRIPTION
The checkout and setup-python action versions were ancient enough to cause CI to not run at all, so figured I'd renovate the rest too.